### PR TITLE
Potential fix for code scanning alert no. 1: Information exposure through a stack trace

### DIFF
--- a/functions/api/puzzle/puz/[base64url].ts
+++ b/functions/api/puzzle/puz/[base64url].ts
@@ -27,8 +27,9 @@ export const onRequestGet: PagesFunction<Env> = async ({ params, env }) => {
     const puzzle = await getPuzzle(url, env);
     return new Response(JSON.stringify(puzzle));
   } catch (e) {
-    // There's no logging for Cloudflare Functions, yet :(
-    return new Response(e?.stack ?? JSON.stringify(e), { status: 500 });
+    // Log the error details for debugging purposes
+    console.error("Error occurred while processing request:", e);
+    return new Response("An internal server error occurred.", { status: 500 });
   }
 };
 


### PR DESCRIPTION
Potential fix for [https://github.com/skiff-bros-and-co/gridunlock/security/code-scanning/1](https://github.com/skiff-bros-and-co/gridunlock/security/code-scanning/1)

To fix the issue, we will modify the error-handling logic to ensure that no sensitive information, such as stack traces or serialized error objects, is exposed to the user. Instead, we will return a generic error message to the user while preserving the error details for potential server-side logging in the future.

1. Replace the response body in the `catch` block with a generic error message like `"An internal server error occurred."`.
2. Remove the inclusion of `e?.stack` and `JSON.stringify(e)` in the response.
3. Optionally, add a placeholder for logging the error details (e.g., `console.error`) to aid debugging during development.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
